### PR TITLE
Add SwiftUI pedal tuner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Swift Package Manager build artifacts
+**/.build/

--- a/PedalTuner/Package.swift
+++ b/PedalTuner/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "PedalTuner",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .library(name: "PedalTuner", targets: ["PedalTuner"])
+    ],
+    targets: [
+        .target(
+            name: "PedalTuner",
+            path: "Sources/PedalTuner"
+        ),
+        .testTarget(
+            name: "PedalTunerTests",
+            dependencies: ["PedalTuner"],
+            path: "Tests/PedalTunerTests"
+        )
+    ]
+)

--- a/PedalTuner/README.md
+++ b/PedalTuner/README.md
@@ -1,0 +1,11 @@
+# PedalTuner
+
+A SwiftUI based tuner interface inspired by a pedal-style canvas tuner. The interface mimics the pedal's circular display and provides live pitch detection using `AVAudioEngine`.
+
+## Features
+- Circular gradient ring similar to the Canvas tuner.
+- Needle style indicator showing pitch deviation in cents.
+- Displays detected note name.
+
+## Building
+This project is packaged as a Swift Package and can be opened in Xcode as an iOS application. Run the app on a device to access the microphone and see the tuner in action.

--- a/PedalTuner/Sources/PedalTuner/AudioTuner.swift
+++ b/PedalTuner/Sources/PedalTuner/AudioTuner.swift
@@ -1,0 +1,80 @@
+#if canImport(AVFoundation)
+import AVFoundation
+import Accelerate
+import SwiftUI
+
+final class AudioTuner: ObservableObject {
+    private let engine = AVAudioEngine()
+    private let session = AVAudioSession.sharedInstance()
+
+    @Published var note: String = "--"
+    @Published var cents: Double = 0
+
+    func start() {
+        configureSession()
+        let input = engine.inputNode
+        let bus = 0
+        let format = input.outputFormat(forBus: bus)
+
+        input.installTap(onBus: bus, bufferSize: 2048, format: format) { [weak self] buffer, _ in
+            self?.process(buffer: buffer)
+        }
+
+        do {
+            try engine.start()
+        } catch {
+            print("Engine start error: \(error)")
+        }
+    }
+
+    private func configureSession() {
+        do {
+            try session.setCategory(.playAndRecord, mode: .measurement, options: [.defaultToSpeaker])
+            try session.setActive(true)
+        } catch {
+            print("Session error: \(error)")
+        }
+    }
+
+    private func process(buffer: AVAudioPCMBuffer) {
+        guard let channelData = buffer.floatChannelData?.pointee else { return }
+        let frameLength = Int(buffer.frameLength)
+        var autocorr = [Float](repeating: 0, count: frameLength)
+        vDSP_conv(channelData, 1, channelData, 1, &autocorr, 1, vDSP_Length(frameLength), vDSP_Length(frameLength))
+
+        var maxIndex = 0
+        var maxValue: Float = 0
+        for lag in 1..<frameLength {
+            let value = autocorr[lag]
+            if value > maxValue {
+                maxValue = value
+                maxIndex = lag
+            }
+        }
+
+        let sampleRate = buffer.format.sampleRate
+        let frequency = sampleRate / Double(maxIndex)
+        updateDisplay(frequency: frequency)
+    }
+
+    private func updateDisplay(frequency: Double) {
+        guard frequency > 0 && frequency.isFinite else { return }
+        let a4 = 440.0
+        let noteNumber = 12 * log2(frequency / a4) + 69
+        let rounded = Int(round(noteNumber))
+        let noteIndex = (rounded + 1200) % 12
+        let names = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+        let diff = noteNumber - Double(rounded)
+        DispatchQueue.main.async {
+            self.note = names[noteIndex]
+            self.cents = diff * 100
+        }
+    }
+}
+#else
+final class AudioTuner {
+    var note: String = "--"
+    var cents: Double = 0
+    func start() { }
+}
+#endif

--- a/PedalTuner/Sources/PedalTuner/ContentView.swift
+++ b/PedalTuner/Sources/PedalTuner/ContentView.swift
@@ -1,0 +1,19 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var tuner = AudioTuner()
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            VStack {
+                Spacer()
+                TunerView(note: tuner.note, cents: tuner.cents)
+                Spacer()
+            }
+        }
+        .onAppear { tuner.start() }
+    }
+}
+#endif

--- a/PedalTuner/Sources/PedalTuner/PedalTunerApp.swift
+++ b/PedalTuner/Sources/PedalTuner/PedalTunerApp.swift
@@ -1,0 +1,12 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+@main
+struct PedalTunerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+#endif

--- a/PedalTuner/Sources/PedalTuner/TunerView.swift
+++ b/PedalTuner/Sources/PedalTuner/TunerView.swift
@@ -1,0 +1,37 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct TunerView: View {
+    var note: String
+    var cents: Double // +/- cents offset
+
+    private var angle: Double {
+        cents * 0.9 // map cents to angle (~0.9 degrees per cent)
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [.teal, .blue]),
+                        center: .center
+                    ),
+                    lineWidth: 16
+                )
+                .padding(40)
+
+            Capsule()
+                .fill(Color.white)
+                .frame(width: 4, height: 120)
+                .offset(y: -60)
+                .rotationEffect(.degrees(angle))
+                .animation(.linear(duration: 0.1), value: angle)
+
+            Text(note)
+                .font(.system(size: 64, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+        }
+    }
+}
+#endif

--- a/PedalTuner/Tests/PedalTunerTests/PedalTunerTests.swift
+++ b/PedalTuner/Tests/PedalTunerTests/PedalTunerTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import PedalTuner
+
+final class PedalTunerTests: XCTestCase {
+    func testDefaultState() {
+        let tuner = AudioTuner()
+        XCTAssertEqual(tuner.note, "--")
+        XCTAssertEqual(tuner.cents, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- create `PedalTuner` Swift package with SwiftUI interface mimicking a pedal-style circular tuner
- include pitch detection using `AVAudioEngine` and display note/cents
- add unit test and ignore build artifacts

## Testing
- `cd PedalTuner && swift test`


------
https://chatgpt.com/codex/tasks/task_e_68bb404028a48331978fcaa671e863af